### PR TITLE
fetcher: rename method

### DIFF
--- a/crypbot/fetcher/base_fetcher.py
+++ b/crypbot/fetcher/base_fetcher.py
@@ -9,7 +9,7 @@ class BaseFetcher(metaclass=abc.ABCMeta):
     """Base class for fetcher."""
 
     @abc.abstractmethod
-    def get_candle(self) -> Optional[Dict]:
+    def fetch_candle(self) -> Optional[Dict]:
         """Return a current candle as a dictionary.
 
         Returns:

--- a/crypbot/fetcher/simulated_fetcher.py
+++ b/crypbot/fetcher/simulated_fetcher.py
@@ -55,7 +55,7 @@ class SimulatedFetcher(BaseFetcher):
             return False
         return True
 
-    def get_candle(self) -> Optional[Dict]:
+    def fetch_candle(self) -> Optional[Dict]:
         """Get a candle info.
 
         Returns:

--- a/tests/simulated_fetcher_test.py
+++ b/tests/simulated_fetcher_test.py
@@ -20,7 +20,7 @@ class SimulatedFetcherTest(unittest.TestCase):
         """Test `initilaize`."""
         self.assertEqual(self.fetcher.ncandles, 10)
 
-    def test_get_candle(self):
-        """Test `get_candle`."""
-        candle = self.fetcher.get_candle()
+    def test_fetch_candle(self):
+        """Test `fetch_candle`."""
+        candle = self.fetcher.fetch_candle()
         self.assertEqual(candle["market"], "KRW-BTC")


### PR DESCRIPTION
This commit renames a method of `fetcher` as below:
- asis: `get_candle`
- tobe: `fetch_candle`